### PR TITLE
Allow read models to have non-string IDs.

### DIFF
--- a/src/Broadway/ReadModel/InMemory/InMemoryRepository.php
+++ b/src/Broadway/ReadModel/InMemory/InMemoryRepository.php
@@ -29,7 +29,7 @@ class InMemoryRepository implements RepositoryInterface, TransferableInterface
      */
     public function save(ReadModelInterface $model)
     {
-        $this->data[$model->getId()] = $model;
+        $this->data[(string) $model->getId()] = $model;
     }
 
     /**
@@ -37,6 +37,7 @@ class InMemoryRepository implements RepositoryInterface, TransferableInterface
      */
     public function find($id)
     {
+        $id = (string) $id;
         if (isset($this->data[$id])) {
             return $this->data[$id];
         }
@@ -93,6 +94,6 @@ class InMemoryRepository implements RepositoryInterface, TransferableInterface
      */
     public function remove($id)
     {
-        unset($this->data[$id]);
+        unset($this->data[(string) $id]);
     }
 }


### PR DESCRIPTION
There is no reason why a read model's id should be a string. Being able
to cast the ID to a string is enough.
