### PR TITLE
[hack] change event store uuid type to string.

### DIFF
--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -59,7 +59,7 @@ class DBALEventStore implements EventStoreInterface
     public function load($id)
     {
         $statement = $this->prepareLoadStatement();
-        $statement->bindValue('uuid', (string) $id, 'guid');
+        $statement->bindValue('uuid', (string) $id, 'string');
         $statement->execute();
 
         $events = array();
@@ -134,7 +134,7 @@ class DBALEventStore implements EventStoreInterface
         $table = $schema->createTable($this->tableName);
 
         $table->addColumn('id', 'integer', array('autoincrement' => true));
-        $table->addColumn('uuid', 'guid', array('length' => 36));
+        $table->addColumn('uuid', 'string', array('length' => 36));
         $table->addColumn('playhead', 'integer', array('unsigned' => true));
         $table->addColumn('payload', 'text');
         $table->addColumn('metadata', 'text');


### PR DESCRIPTION
The DBAL event store uses `guid` as its type for event uuids (which
makes sense). Unfortunately, we use string IDs in our tests for
convenience (like "offer_1"). The type should be configurable, but
we'll just use `string` for the time being.
