### PR TITLE
[cli] Adding a existence test on table before droping

### DIFF
--- a/src/Broadway/Bundle/BroadwayBundle/Command/SchemaEventStoreDropCommand.php
+++ b/src/Broadway/Bundle/BroadwayBundle/Command/SchemaEventStoreDropCommand.php
@@ -54,9 +54,13 @@ EOT
             $eventStore    = $this->getEventStore();
 
             $table = $eventStore->configureTable();
-            $schemaManager->dropTable($table->getName());
+            if($schemaManager->tablesExist(array($table->getName()))) {
+                $schemaManager->dropTable($table->getName());
+                $output->writeln('<info>Dropped Broadway event-store schema</info>');
+            } else {
+                $output->writeln('<info>Broadway event-store schema does not exist</info>');
+            }
 
-            $output->writeln('<info>Dropped Broadway event-store schema</info>');
         } catch (Exception $e) {
             $output->writeln('<error>Could not drop Broadway event-store schema</error>');
             $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));


### PR DESCRIPTION
In a some context we could launch the command to be sure that the table doesn't exist.
The fact that the table doesn't exist shouldn't make command to fail.